### PR TITLE
make Development link version agnostic

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
 			<p>When combined with a 3rd party interactive desktop Point Of Sale system it can also form the hub of a dispersed multi-branch retail management system.</p>
 			<p>A fully integrated webSHOP is also available as a 3rd party add-on.</p>
 			<p>webERP is as an open-source application and is available as a free download to use with all the PHP code written in an accessible way for you to add your own features as needed.</p>
+			<p>The current release of webERP is 4.15.2 for PHP v7. webERP v5 will support PHP8 and is in the final stages of development and due to be released soon.</p>
 		</fieldset>
 	</main>
 
@@ -73,11 +74,11 @@
 					<p> Click here to find out how</p>
 				</div>
 			</a>
-			<a class="ItemLink" href="https://github.com/timschofield/webERP/releases/tag/v4.15.2" target="_blank">
+			<a class="ItemLink" href="https://github.com/timschofield/webERP/releases" target="_blank">
 				<div>
 					<img class="icons" src="images/downloads.avif" title="Icon downloaded from here - https://www.flaticon.com/free-icons/download" alt="Downloads" />
 					<span class="title">Downloads</span>
-					<p> The latest version of webERP is version 4.15.2 and can be downloaded from Github.</p>
+					<p> Download webERP releases from GitHub.</p>
 					<p> Click here to download</p>
 				</div>
 			</a>
@@ -146,7 +147,7 @@ class="about-link" href="https://github.com/timschofield/webERP/wiki/Installer">
 			</a>
 		<!-- End SF Tag -->
 		</div>
-		<span id="copyright">&copy Tim Schofield 2024</span>
+		<span id="copyright">&copy Tim Schofield 2024 &copy webERP community</span>
 	</footer>
 
 	</body>


### PR DESCRIPTION
Down a bit of a rabbit hole. Started with how to propose a change to the "v5" page, had to figure out what links from the website were to static pages and which were links to somewhere else, noticed the "Development" link on the main mage linked to a specific version while the other links were version-agnostic, and thought it should be changed (and in the process, moved the description of the current version from the development link to the end of the feature list. I also changed the website copyright footer to be consistent with the code (I'm assuming this was your intention @timschofield, if not please fee free to accept only parts of this pull request or none at all). 